### PR TITLE
Minor improvements (needed to run in our environment)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -56,3 +56,10 @@ CSV FILE REQUIREMENTS
 - Has a "UserID" column
 - Delimitor: ";"
 - No column "Email" in the start file
+
+HINT FOR USERS IN RESTRICTED ENVIRONMENTS
+------------------------------------------
+If the execution of PowerShell script is restricted, you can try to temporary disable the restriction.
+Enter the following command in PowerShell:
+
+	Set-ExecutionPolicy -Scope CurrentUser unrestricted

--- a/add_email_from_eduid.ps1
+++ b/add_email_from_eduid.ps1
@@ -92,7 +92,7 @@ foreach ($FILE_ABSOLUTE_PATH in $filesToProcess) {
 		$rowsCount = (Import-Csv $FILE_ABSOLUTE_PATH -Delimiter ';' | Measure-Object).count
 
 		# Create name of the output file
-		$FILE_ABSOLUTE_PATH_DESTINATION = ($FILE_ABSOLUTE_PATH -split "\.")[0] + '_processed.csv'	
+		$FILE_ABSOLUTE_PATH_DESTINATION = $FILE_ABSOLUTE_PATH -replace '\.[^\.]+$', '_processed.csv'	
 
 	} elseif ( $EXTENSION -eq ".xlsx" ){
 		###########################
@@ -103,7 +103,7 @@ foreach ($FILE_ABSOLUTE_PATH in $filesToProcess) {
 		$ExcelObj = New-Object -comobject Excel.Application
 
 		# Create name of the output file
-		$FILE_ABSOLUTE_PATH_DESTINATION = ($FILE_ABSOLUTE_PATH -split "\.")[0] + '_processed.xlsx'
+		$FILE_ABSOLUTE_PATH_DESTINATION = $FILE_ABSOLUTE_PATH -replace '\.[^\.]+$', '_processed.xlsx'
 
 		# Open excel file
 		$ExcelWorkBook = $ExcelObj.Workbooks.Open($FILE_ABSOLUTE_PATH)

--- a/add_email_from_eduid.ps1
+++ b/add_email_from_eduid.ps1
@@ -196,8 +196,8 @@ Start process...
 			$prefEmail = get_email
 
 			$ws.cells.Item($row_counter, $emailCol).value = $prefEmail
-			$ExcelWorkBook.Save()
 		}
+		$ExcelWorkBook.Save()
 		$ExcelWorkBook.close()
 	}
 }

--- a/add_email_from_eduid.ps1
+++ b/add_email_from_eduid.ps1
@@ -16,7 +16,7 @@ function get_email {
 	Write-Host "Row ${row_counter}/${rowsCount}: get data for user ""${userId}"" ..."
 	
 	try {
-		$response = Invoke-WebRequest -Uri "https://api-eu.hosted.exlibrisgroup.com/almaws/v1/users/${userId}?apikey=${API_KEY}&format=json" | ConvertFrom-Json
+		$response = Invoke-WebRequest -Uri "https://api-eu.hosted.exlibrisgroup.com/almaws/v1/users/${userId}?apikey=${API_KEY}&format=json" -UseBasicParsing | ConvertFrom-Json
 	}
 	catch {
 		$errorMessage = $_

--- a/add_email_from_eduid.ps1
+++ b/add_email_from_eduid.ps1
@@ -196,8 +196,8 @@ Start process...
 			$prefEmail = get_email
 
 			$ws.cells.Item($row_counter, $emailCol).value = $prefEmail
+			$ExcelWorkBook.Save()
 		}
-		$ExcelWorkBook.Save()
 		$ExcelWorkBook.close()
 	}
 }

--- a/add_email_from_eduid.ps1
+++ b/add_email_from_eduid.ps1
@@ -18,8 +18,9 @@ function get_email {
 	try {
 		$response = Invoke-WebRequest -Uri "https://api-eu.hosted.exlibrisgroup.com/almaws/v1/users/${userId}?apikey=${API_KEY}&format=json" | ConvertFrom-Json
 	}
-	catch{
-		Write-Host "Failed to fetch data for user ${userId}" -ForegroundColor red
+	catch {
+		$errorMessage = $_
+		Write-Host "Failed to fetch data for user ${userId}: $errorMessage" -ForegroundColor red
 		continue
 	}
 	


### PR DESCRIPTION
Hi @Raphael-Rey 

Thank you for this script, this is really useful! Sadly, the script did not run 'out of the box' in our environment, so I made some changes. The changes are not specific for our environment, so I thought I could contribute to your script. I hope you consider merging this pull request.

The changes are the following:
- Print the error message when the API call fails. This was the case when I executed the script the first time, and this helps to find the cause.
- Add `-UseBasicParsing` as parameter to `Invoke-Webrequest`. Since we use PowerShell 5.x, `Invoke-Webrequest` still uses Internet Explorer for DOM parsing. This can be avoided with this parameter (which is default in PowerShell 6.x+).
- When generating the filename for the output file, the split [0] replaced all after the first dot. This does not work, when the filename contains a dot (not just for the extension), e.g. when using dates or 'St.Gallen'. The now used regex should match the last dot in the name.
- Small performance improvement: Save the Excel after the loop.
- Add a hint on how to run PowerShell scripts in restricted environments.

BR
Jonas